### PR TITLE
Globally Enable Mapped Errors

### DIFF
--- a/lib/express_validator.js
+++ b/lib/express_validator.js
@@ -60,6 +60,7 @@ function Sanitizer(param, req, locations) {
 var expressValidator = function(options) {
   options = options || {};
   var defaults = {
+    mappedErrors: false,
     customValidators: {},
     customSanitizers: {},
     errorFormatter: function(param, msg, value) {
@@ -155,6 +156,9 @@ var expressValidator = function(options) {
     req._validationErrors = [];
     req._asyncValidationErrors = [];
     req.validationErrors = function(mapped, promisesResolved) {
+      if(typeof mapped === 'undefined') {
+        mapped = options.mappedErrors;
+      }
       if (!promisesResolved && req._asyncValidationErrors.length > 0) {
         console.warn('WARNING: You have asynchronous validators but you have not used asyncValidateErrors to check for errors.');
       }
@@ -172,6 +176,9 @@ var expressValidator = function(options) {
     };
 
     req.asyncValidationErrors = function(mapped) {
+      if(typeof mapped === 'undefined') {
+        mapped = options.mappedErrors;
+      }
       return new Promise(function(resolve, reject) {
         var promises = req._asyncValidationErrors;
         // Migrated using the recommended fix from


### PR DESCRIPTION
I think it is a common scenario where one would want to either enable or disable mapped errors throughout an application for consistency reasons. It's a little difficult to maintain when we need to pass 'true' to each req.validationErrors() or req.asyncValidationErrors() calls.
